### PR TITLE
fix: annotate model after .mat and .yml export, but before .xml export

### DIFF
--- a/code/masterScriptRatGEM.m
+++ b/code/masterScriptRatGEM.m
@@ -42,10 +42,10 @@ if isequal(rxnAssoc.rxns, ratGEM.rxns) && isequal(metAssoc.mets, ratGEM.mets)
     exportTsvFile(metAssoc,'../model/metabolites.tsv');
 end
 
-ratGEM = annotateGEM(ratGEM,'../model',{'rxn','met'});  % add annotation data to structure
-ratGEM.id = regexprep(ratGEM.id,'-','');  % remove dash from model ID since it causes problems with SBML I/O
 save('../model/Rat-GEM.mat', 'ratGEM');
 exportYaml(ratGEM, '../model/Rat-GEM.yml');
+ratGEM = annotateGEM(ratGEM,'../model',{'rxn','met'});  % add annotation data to structure
+ratGEM.id = regexprep(ratGEM.id,'-','');  % remove dash from model ID since it causes problems with SBML I/O
 exportModel(ratGEM, '../model/Rat-GEM.xml');
 
 


### PR DESCRIPTION
### Main improvements in this PR:
As described in [Issue 16 of Mouse-GEM](https://github.com/SysBioChalmers/Mouse-GEM/issues/16) and addressed in PR [18](https://github.com/SysBioChalmers/Mouse-GEM/pull/18) of that same repo, the master script for regenerating the model files (`masterScriptRatGEM.m` in this repo) is modified such that the addition of non-standard metabolite and reaction annotation fields are only added to the SBML (`.xml`) version of the model. The `.mat` and `.yml` versions should not contain these fields.

**I hereby confirm that I have:**

- [X] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch